### PR TITLE
AGP Upgradte to alpha 06

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.0.0-alpha05")
+        classpath("com.android.tools.build:gradle:${AndroidApp.AGP_VERSION}")
         classpath(kotlin("gradle-plugin", version = Dependency.Kotlin.VERSION))
     }
 }

--- a/buildSrc/src/main/kotlin/Configuration.kt
+++ b/buildSrc/src/main/kotlin/Configuration.kt
@@ -10,6 +10,8 @@ object AndroidApp {
     const val VERSION_CODE = 1
     const val VERSION_NAME = "1.0.0"
 
+    const val AGP_VERSION = "7.0.0-alpha06"
+
     const val INSTRUMENTATION_TEST_RUNNER = "androidx.test.runner.AndroidJUnitRunner"
 
     object Dimension


### PR DESCRIPTION
The purpose of the upgrade is to match the last AS alpha version.
